### PR TITLE
Sync deleted XForms, Instances and Projects

### DIFF
--- a/kaznet/apps/main/tests/models/test_submissions.py
+++ b/kaznet/apps/main/tests/models/test_submissions.py
@@ -15,8 +15,6 @@ class TestSubmission(MainTestBase):
 
     def setUp(self):
         super().setUp()
-        self.instance_type = get_allowed_contenttypes().filter(
-            model='instance').first()
 
     def test_submission_model_str(self):
         """

--- a/kaznet/apps/main/tests/models/test_submissions.py
+++ b/kaznet/apps/main/tests/models/test_submissions.py
@@ -3,7 +3,6 @@ Test for Submission model
 """
 
 from model_mommy import mommy
-from tasking.utils import get_allowed_contenttypes
 
 from kaznet.apps.main.tests.base import MainTestBase
 

--- a/kaznet/apps/main/tests/models/test_tasks.py
+++ b/kaznet/apps/main/tests/models/test_tasks.py
@@ -5,7 +5,6 @@ Test for Task model
 from __future__ import unicode_literals
 
 from model_mommy import mommy
-from tasking.utils import get_allowed_contenttypes
 
 from kaznet.apps.main.tests.base import MainTestBase
 
@@ -17,8 +16,6 @@ class TestTasks(MainTestBase):
 
     def setUp(self):
         super().setUp()
-        self.instance_type = get_allowed_contenttypes().filter(
-            model='xform').first()
 
     def test_task_model_str(self):
         """
@@ -41,7 +38,7 @@ class TestTasks(MainTestBase):
         )
 
         self.assertEqual(cattle_task.target_object_id, xform.id)
-        self.assertEqual(cattle_task.target_content_type, self.instance_type)
+        self.assertEqual(cattle_task.target_content_type, self.xform_type)
 
     def test_created_by_name(self):
         """

--- a/kaznet/apps/main/tests/serializers/test_submissions.py
+++ b/kaznet/apps/main/tests/serializers/test_submissions.py
@@ -4,9 +4,10 @@ Test for KaznetSubmissionSerializer
 from collections import OrderedDict
 from decimal import Decimal
 
-import pytz
 from django.contrib.auth import get_user_model
 from django.utils import timezone
+
+import pytz
 from model_mommy import mommy
 
 from kaznet.apps.main.models import Submission

--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -649,3 +649,18 @@ def create_form_webhook(
         form.save()
 
         return response
+
+
+def sync_deleted_projects(username: str = settings.ONA_USERNAME):
+    """
+    Checks for deleted projects on Onadata
+    If it finds any, it deletes them locally
+    """
+    onadata_projects = get_projects(username=username)
+    onadata_project_pks = [rec['projectid'] for rec in onadata_projects] 
+    local_projects = Project.objects.filter(deleted_at=None)
+    deleted_projects = local_projects.exclude(ona_pk__in=onadata_project_pks)
+
+    # delete in such a way that any signals are sent
+    for proj in deleted_projects:
+        proj.delete()

--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -680,13 +680,15 @@ def sync_deleted_projects(username: str = settings.ONA_USERNAME):
     If it finds any, it deletes them locally
     """
     onadata_projects = get_projects(username=username)
-    onadata_project_pks = [rec['projectid'] for rec in onadata_projects]
-    local_projects = Project.objects.filter(deleted_at=None)
-    deleted_projects = local_projects.exclude(ona_pk__in=onadata_project_pks)
+    if isinstance(onadata_projects, list) and onadata_projects:
+        onadata_project_pks = [rec['projectid'] for rec in onadata_projects]
+        local_projects = Project.objects.filter(deleted_at=None)
+        deleted_projects = local_projects.exclude(
+            ona_pk__in=onadata_project_pks)
 
-    # delete projects safely
-    for proj in deleted_projects:
-        delete_project(proj)
+        # delete projects safely
+        for proj in deleted_projects:
+            delete_project(proj)
 
 
 def sync_deleted_xforms(username: str = settings.ONA_USERNAME):
@@ -696,10 +698,11 @@ def sync_deleted_xforms(username: str = settings.ONA_USERNAME):
     """
     onadata_projects = get_projects(username=username)
     onadata_xform_ids = []
-    for project in onadata_projects:
-        project_forms = project.get('forms')
-        xform_ids = [x['formid'] for x in project_forms if x.get('formid')]
-        onadata_xform_ids = onadata_xform_ids + xform_ids
+    if isinstance(onadata_projects, list) and onadata_projects:
+        for project in onadata_projects:
+            project_forms = project.get('forms')
+            xform_ids = [x['formid'] for x in project_forms if x.get('formid')]
+            onadata_xform_ids = onadata_xform_ids + xform_ids
 
     local_xforms = XForm.objects.filter(deleted_at=None)
 

--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -657,7 +657,7 @@ def sync_deleted_projects(username: str = settings.ONA_USERNAME):
     If it finds any, it deletes them locally
     """
     onadata_projects = get_projects(username=username)
-    onadata_project_pks = [rec['projectid'] for rec in onadata_projects] 
+    onadata_project_pks = [rec['projectid'] for rec in onadata_projects]
     local_projects = Project.objects.filter(deleted_at=None)
     deleted_projects = local_projects.exclude(ona_pk__in=onadata_project_pks)
 

--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -23,6 +23,7 @@ from kaznet.apps.main.common_tags import (FILTERED_DATASETS_FIELD_NAME,
                                           WEBHOOK_FIELD_NAME)
 from kaznet.apps.main.models import Submission
 from kaznet.apps.ona.models import Instance, Project, XForm
+from kaznet.apps.ona.utils import delete_project
 from kaznet.apps.users.models import UserProfile
 
 SUCCESS_STATUSES = [200, 201]
@@ -661,6 +662,6 @@ def sync_deleted_projects(username: str = settings.ONA_USERNAME):
     local_projects = Project.objects.filter(deleted_at=None)
     deleted_projects = local_projects.exclude(ona_pk__in=onadata_project_pks)
 
-    # delete in such a way that any signals are sent
+    # delete project safely
     for proj in deleted_projects:
-        proj.delete()
+        delete_project(proj)

--- a/kaznet/apps/ona/signals.py
+++ b/kaznet/apps/ona/signals.py
@@ -7,7 +7,6 @@ from django.db.models.signals import post_save, pre_delete
 from kaznet.apps.main.common_tags import (HAS_FILTERED_DATASETS_FIELD_NAME,
                                           HAS_WEBHOOK_FIELD_NAME)
 from kaznet.apps.main.models import Task
-from kaznet.apps.ona.models import Instance, XForm
 from kaznet.apps.ona.tasks import (task_auto_create_filtered_data_sets,
                                    task_create_form_webhook)
 
@@ -24,24 +23,6 @@ def delete_xform(sender, instance, **kwargs):
         task.status = Task.DRAFT
         task.target_content_object = None
         task.save()
-
-        # delete submissions in a way that signals are called
-        for sub in task.submission_set.all():
-            sub.delete()
-
-
-def delete_project(sender, instance, **kwargs):
-    """
-    Predelete signal handler for Project objects
-    """
-    # delete any Instances in a way that signals are called
-    ona_instances = Instance.objects.filter(xform__project=instance)
-    for ona_instance in ona_instances:
-        ona_instance.delete()
-    # delete any XForms in a way that signals are called
-    xforms = XForm.objects.filter(project=instance)
-    for xform in xforms:
-        xform.delete()
 
 
 # pylint: disable=unused-argument
@@ -74,11 +55,6 @@ pre_delete.connect(
     delete_xform,
     sender='ona.XForm',
     dispatch_uid='delete_xform')
-
-pre_delete.connect(
-    delete_project,
-    sender='ona.Project',
-    dispatch_uid='delete_project')
 
 post_save.connect(
     auto_create_ona_filtered_data_sets,

--- a/kaznet/apps/ona/tasks.py
+++ b/kaznet/apps/ona/tasks.py
@@ -5,18 +5,18 @@ from datetime import timedelta
 from time import sleep
 from urllib.parse import urljoin
 
+from celery import task as celery_task
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.urls import reverse
 from django.utils import timezone
-
-from celery import task as celery_task
 
 from kaznet.apps.main.models import Task
 from kaznet.apps.ona.api import (create_filtered_data_sets,
                                  create_form_webhook, fetch_missing_instances,
                                  get_and_process_xforms, get_projects,
                                  process_projects, sync_deleted_instances,
+                                 sync_deleted_projects, sync_deleted_xforms,
                                  sync_updated_instances,
                                  update_user_profile_metadata)
 from kaznet.apps.ona.models import XForm
@@ -176,3 +176,21 @@ def task_sync_deleted_instances():
     xforms = XForm.objects.filter(deleted_at=None)
     for xform in xforms:
         task_sync_form_deleted_instances.delay(xform_id=xform.id)
+
+
+# pylint: disable=not-callable
+@celery_task(name="task_sync_deleted_xforms")
+def task_sync_deleted_xforms(username: str):
+    """
+    checks for deleted xforms and syncs them
+    """
+    sync_deleted_xforms(username=username)
+
+
+# pylint: disable=not-callable
+@celery_task(name="task_sync_deleted_projects")
+def task_sync_deleted_projects(username: str):
+    """
+    checks for deleted projects and syncs them
+    """
+    sync_deleted_projects(username=username)

--- a/kaznet/apps/ona/tests/test_api.py
+++ b/kaznet/apps/ona/tests/test_api.py
@@ -114,19 +114,19 @@ class TestApiMethods(MainTestBase):
         """
         Project.objects.all().delete()
         proj = mommy.make('ona.Project', ona_pk=1337)
-        
+
         # make 3 more projects
         mommy.make('ona.Project', _quantity=3)
-        
+
         # make some forms
         proj_with_submissions = mommy.make('ona.Project')
         xform = mommy.make('ona.XForm', ona_project_id=1337,
                            project=proj_with_submissions)
-        
+
         xform_id = xform.id
         deleted_projects = Project.objects.exclude(
             id=proj.id).values_list('id', flat=True)
-        
+
         # make some instances
         mommy.make('ona.Instance', _quantity=13, xform=xform)
         instance = mommy.make('ona.Instance', xform=xform)

--- a/kaznet/apps/ona/tests/test_api.py
+++ b/kaznet/apps/ona/tests/test_api.py
@@ -18,7 +18,7 @@ from kaznet.apps.main.common_tags import (FILTERED_DATASETS_FIELD_NAME,
                                           HAS_FILTERED_DATASETS_FIELD_NAME,
                                           HAS_WEBHOOK_FIELD_NAME,
                                           WEBHOOK_FIELD_NAME)
-from kaznet.apps.main.models import Task
+from kaznet.apps.main.models import Task, Submission
 from kaznet.apps.main.tests.base import MainTestBase
 from kaznet.apps.ona.api import (create_filtered_data_sets,
                                  create_filtered_dataset, create_form_webhook,
@@ -114,6 +114,10 @@ class TestApiMethods(MainTestBase):
         Test sync_deleted_projects
         """
         Project.objects.all().delete()
+        XForm.objects.all().delete()
+        Instance.objects.all().delete()
+        Submission.objects.all().delete()
+
         proj = mommy.make('ona.Project', ona_pk=1337)
 
         # make 3 more projects
@@ -1514,6 +1518,9 @@ class TestApiMethods(MainTestBase):
         Test sync_deleted_xforms
         """
         XForm.objects.all().delete()
+        Instance.objects.all().delete()
+        Submission.objects.all().delete()
+
         xform = mommy.make('ona.XForm', ona_pk=53)
 
         # make one more xform

--- a/kaznet/apps/ona/tests/test_celery_tasks.py
+++ b/kaznet/apps/ona/tests/test_celery_tasks.py
@@ -4,12 +4,11 @@ Test module for celery tasks for Ona app
 from unittest.mock import call, patch
 from urllib.parse import urljoin
 
+import requests_mock
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.test import override_settings
 from django.utils import timezone
-
-import requests_mock
 from model_mommy import mommy
 
 from kaznet.apps.main.models import Task
@@ -23,6 +22,8 @@ from kaznet.apps.ona.tasks import (task_auto_create_filtered_data_sets,
                                    task_process_project_xforms,
                                    task_process_user_profiles,
                                    task_sync_deleted_instances,
+                                   task_sync_deleted_projects,
+                                   task_sync_deleted_xforms,
                                    task_sync_form_deleted_instances,
                                    task_sync_form_updated_instances,
                                    task_sync_updated_instances,
@@ -570,3 +571,21 @@ class TestCeleryTasks(MainTestBase):
         ]
 
         sync_deleted_instances_mock.assert_has_calls(expected_calls)
+
+    @patch('kaznet.apps.ona.tasks.sync_deleted_xforms')
+    def test_task_sync_deleted_xforms(self, mock):
+        """
+        Test task_sync_deleted_xforms
+        """
+        # call the task
+        task_sync_deleted_xforms(username="mosh")
+        mock.assert_called_once_with(username="mosh")
+
+    @patch('kaznet.apps.ona.tasks.sync_deleted_projects')
+    def test_task_sync_deleted_projects(self, mock):
+        """
+        Test task_sync_deleted_projects
+        """
+        # call the task
+        task_sync_deleted_projects(username="mosh")
+        mock.assert_called_once_with(username="mosh")

--- a/kaznet/apps/ona/tests/test_utils.py
+++ b/kaznet/apps/ona/tests/test_utils.py
@@ -12,8 +12,8 @@ from model_mommy import mommy
 
 from kaznet.apps.main.models import Bounty, Location, Submission, Task
 from kaznet.apps.main.tests.base import MainTestBase
-from kaznet.apps.ona.models import Instance, XForm
-from kaznet.apps.ona.utils import delete_instance, delete_xform
+from kaznet.apps.ona.models import Instance, XForm, Project
+from kaznet.apps.ona.utils import delete_instance, delete_project, delete_xform
 
 
 class TestUtils(MainTestBase):
@@ -158,7 +158,7 @@ class TestUtils(MainTestBase):
 
     def test_delete_xform_atomic(self):
         """
-        Test delete_xform
+        Test delete_xform is atomic
         """
         xform = mommy.make('ona.XForm')
         instance = mommy.make('ona.Instance', xform=xform)
@@ -216,6 +216,155 @@ class TestUtils(MainTestBase):
 
         # nothing was deleted
         self.assertTrue(XForm.objects.filter(id=xform.id).exists())
+        self.assertTrue(Instance.objects.filter(id=instance.id).exists())
+        self.assertTrue(Submission.objects.filter(id=submission.id).exists())
+        self.assertTrue(Bounty.objects.filter(id=bounty.id).exists())
+        self.assertTrue(Location.objects.filter(id=location.id).exists())
+        self.assertTrue(User.objects.filter(id=user.id).exists())
+        self.assertTrue(Task.objects.filter(id=task.id).exists())
+
+        # the task status did not change
+        task.refresh_from_db()
+        self.assertEqual(Task.ACTIVE, task.status)
+
+    def test_delete_project(self):
+        """
+        Test delete_xform
+        """
+        project = mommy.make('ona.Project')
+        xform = mommy.make('ona.XForm', project=project)
+        xform2 = mommy.make('ona.XForm', ona_project_id=project.ona_pk)
+        instance = mommy.make('ona.Instance', xform=xform)
+        task = mommy.make(
+            'main.Task', name='Quest',
+            target_object_id=xform.id,
+            target_content_type=self.xform_type,
+            status=Task.ACTIVE
+        )
+        location = mommy.make('main.Location', name='Voi')
+        user = mommy.make('auth.User', first_name='Coco')
+        bounty = mommy.make(
+            'main.Bounty', task=task, amount=Money('50', 'KES'))
+        submission = mommy.make(
+            'main.Submission',
+            task=task,
+            location=location,
+            user=user,
+            submission_time=parse("2018-09-04T00:00:00+00:00"),
+            status=Submission.APPROVED,
+            target_object_id=instance.id,
+            target_content_type=self.instance_type
+        )
+
+        delete_project(project=project)
+
+        # the Project, XForm, Instance and Submission were deleted
+        self.assertFalse(Project.objects.filter(id=project.id).exists())
+        self.assertFalse(XForm.objects.filter(id=xform.id).exists())
+        self.assertFalse(XForm.objects.filter(id=xform2.id).exists())
+        self.assertFalse(Instance.objects.filter(id=instance.id).exists())
+        self.assertFalse(Submission.objects.filter(id=submission.id).exists())
+
+        # these other models were not deleted
+        self.assertTrue(Bounty.objects.filter(id=bounty.id).exists())
+        self.assertTrue(Location.objects.filter(id=location.id).exists())
+        self.assertTrue(User.objects.filter(id=user.id).exists())
+        self.assertTrue(Task.objects.filter(id=task.id).exists())
+
+        # the task is now draft
+        task.refresh_from_db()
+        self.assertEqual(Task.DRAFT, task.status)
+
+    def test_delete_project_atomic(self):
+        """
+        Test delete_project is atomic
+        """
+        project = mommy.make('ona.Project')
+        xform = mommy.make('ona.XForm', project=project)
+        xform2 = mommy.make('ona.XForm', ona_project_id=project.ona_pk)
+        instance = mommy.make('ona.Instance', xform=xform)
+        task = mommy.make(
+            'main.Task', name='Quest',
+            target_object_id=xform.id,
+            target_content_type=self.xform_type,
+            status=Task.ACTIVE
+        )
+        location = mommy.make('main.Location', name='Voi')
+        user = mommy.make('auth.User', first_name='Coco')
+        bounty = mommy.make(
+            'main.Bounty', task=task, amount=Money('50', 'KES'))
+        submission = mommy.make(
+            'main.Submission',
+            task=task,
+            location=location,
+            user=user,
+            submission_time=parse("2018-09-04T00:00:00+00:00"),
+            status=Submission.APPROVED,
+            target_object_id=instance.id,
+            target_content_type=self.instance_type
+        )
+
+        with patch('kaznet.apps.ona.models.Project.delete') as mock:
+            # we want a database-level error to happen when we attempt to
+            # delete a project
+            mock.side_effect = IntegrityError
+
+            # this is necessary so that this test does not fail here
+            with self.assertRaises(IntegrityError):
+                delete_project(project=project)
+
+        # nothing deleted
+        self.assertTrue(Project.objects.filter(id=project.id).exists())
+        self.assertTrue(XForm.objects.filter(id=xform.id).exists())
+        self.assertTrue(XForm.objects.filter(id=xform2.id).exists())
+        self.assertTrue(Instance.objects.filter(id=instance.id).exists())
+        self.assertTrue(Submission.objects.filter(id=submission.id).exists())
+        self.assertTrue(Bounty.objects.filter(id=bounty.id).exists())
+        self.assertTrue(Location.objects.filter(id=location.id).exists())
+        self.assertTrue(User.objects.filter(id=user.id).exists())
+        self.assertTrue(Task.objects.filter(id=task.id).exists())
+
+        # the task status did not change
+        task.refresh_from_db()
+        self.assertEqual(Task.ACTIVE, task.status)
+
+        with patch('kaznet.apps.ona.utils.delete_xform') as mock:
+            # we want a database-level error to happen when we attempt to
+            # delete an xform, instance or submission
+            mock.side_effect = IntegrityError
+
+            # this is necessary so that this test does not fail here
+            with self.assertRaises(IntegrityError):
+                delete_project(project=project)
+
+        # nothing deleted
+        self.assertTrue(Project.objects.filter(id=project.id).exists())
+        self.assertTrue(XForm.objects.filter(id=xform.id).exists())
+        self.assertTrue(XForm.objects.filter(id=xform2.id).exists())
+        self.assertTrue(Instance.objects.filter(id=instance.id).exists())
+        self.assertTrue(Submission.objects.filter(id=submission.id).exists())
+        self.assertTrue(Bounty.objects.filter(id=bounty.id).exists())
+        self.assertTrue(Location.objects.filter(id=location.id).exists())
+        self.assertTrue(User.objects.filter(id=user.id).exists())
+        self.assertTrue(Task.objects.filter(id=task.id).exists())
+
+        # the task status did not change
+        task.refresh_from_db()
+        self.assertEqual(Task.ACTIVE, task.status)
+
+        with patch('kaznet.apps.ona.utils.delete_instance') as mock:
+            # we want a database-level error to happen when we attempt to
+            # delete an instance or a submission
+            mock.side_effect = IntegrityError
+
+            # this is necessary so that this test does not fail here
+            with self.assertRaises(IntegrityError):
+                delete_project(project=project)
+
+        # nothing deleted
+        self.assertTrue(Project.objects.filter(id=project.id).exists())
+        self.assertTrue(XForm.objects.filter(id=xform.id).exists())
+        self.assertTrue(XForm.objects.filter(id=xform2.id).exists())
         self.assertTrue(Instance.objects.filter(id=instance.id).exists())
         self.assertTrue(Submission.objects.filter(id=submission.id).exists())
         self.assertTrue(Bounty.objects.filter(id=bounty.id).exists())

--- a/kaznet/apps/ona/tests/test_utils.py
+++ b/kaznet/apps/ona/tests/test_utils.py
@@ -12,8 +12,8 @@ from model_mommy import mommy
 
 from kaznet.apps.main.models import Bounty, Location, Submission, Task
 from kaznet.apps.main.tests.base import MainTestBase
-from kaznet.apps.ona.models import Instance
-from kaznet.apps.ona.utils import delete_instance
+from kaznet.apps.ona.models import Instance, XForm
+from kaznet.apps.ona.utils import delete_instance, delete_xform
 
 
 class TestUtils(MainTestBase):
@@ -111,3 +111,118 @@ class TestUtils(MainTestBase):
         self.assertTrue(Location.objects.filter(id=location.id).exists())
         self.assertTrue(User.objects.filter(id=user.id).exists())
         self.assertTrue(Task.objects.filter(id=task.id).exists())
+
+    def test_delete_xform(self):
+        """
+        Test delete_xform
+        """
+        xform = mommy.make('ona.XForm')
+        instance = mommy.make('ona.Instance', xform=xform)
+        task = mommy.make(
+            'main.Task', name='Quest',
+            target_object_id=xform.id,
+            target_content_type=self.xform_type,
+            status=Task.ACTIVE
+        )
+        location = mommy.make('main.Location', name='Voi')
+        user = mommy.make('auth.User', first_name='Coco')
+        bounty = mommy.make(
+            'main.Bounty', task=task, amount=Money('50', 'KES'))
+        submission = mommy.make(
+            'main.Submission',
+            task=task,
+            location=location,
+            user=user,
+            submission_time=parse("2018-09-04T00:00:00+00:00"),
+            status=Submission.APPROVED,
+            target_object_id=instance.id,
+            target_content_type=self.instance_type
+        )
+
+        delete_xform(xform=xform)
+
+        # the xform, instance and submission were deleted
+        self.assertFalse(XForm.objects.filter(id=xform.id).exists())
+        self.assertFalse(Instance.objects.filter(id=instance.id).exists())
+        self.assertFalse(Submission.objects.filter(id=submission.id).exists())
+
+        # these other models were not deleted
+        self.assertTrue(Bounty.objects.filter(id=bounty.id).exists())
+        self.assertTrue(Location.objects.filter(id=location.id).exists())
+        self.assertTrue(User.objects.filter(id=user.id).exists())
+        self.assertTrue(Task.objects.filter(id=task.id).exists())
+
+        # the task is now draft
+        task.refresh_from_db()
+        self.assertEqual(Task.DRAFT, task.status)
+
+    def test_delete_xform_atomic(self):
+        """
+        Test delete_xform
+        """
+        xform = mommy.make('ona.XForm')
+        instance = mommy.make('ona.Instance', xform=xform)
+        task = mommy.make(
+            'main.Task', name='Quest',
+            target_object_id=xform.id,
+            target_content_type=self.xform_type,
+            status=Task.ACTIVE
+        )
+        location = mommy.make('main.Location', name='Voi')
+        user = mommy.make('auth.User', first_name='Coco')
+        bounty = mommy.make(
+            'main.Bounty', task=task, amount=Money('50', 'KES'))
+        submission = mommy.make(
+            'main.Submission',
+            task=task,
+            location=location,
+            user=user,
+            submission_time=parse("2018-09-04T00:00:00+00:00"),
+            status=Submission.APPROVED,
+            target_object_id=instance.id,
+            target_content_type=self.instance_type
+        )
+
+        with patch('kaznet.apps.ona.utils.delete_instance') as mock:
+            # we want a database-level error to happen when we attempt to
+            # delete an instance or a submission
+            mock.side_effect = IntegrityError
+
+            # this is necessary so that this test does not fail here
+            with self.assertRaises(IntegrityError):
+                delete_xform(xform=xform)
+
+        # nothing was deleted
+        self.assertTrue(XForm.objects.filter(id=xform.id).exists())
+        self.assertTrue(Instance.objects.filter(id=instance.id).exists())
+        self.assertTrue(Submission.objects.filter(id=submission.id).exists())
+        self.assertTrue(Bounty.objects.filter(id=bounty.id).exists())
+        self.assertTrue(Location.objects.filter(id=location.id).exists())
+        self.assertTrue(User.objects.filter(id=user.id).exists())
+        self.assertTrue(Task.objects.filter(id=task.id).exists())
+
+        # the task status did not change
+        task.refresh_from_db()
+        self.assertEqual(Task.ACTIVE, task.status)
+
+        with patch('kaznet.apps.ona.models.XForm.delete') as mock:
+            # we want a database-level error to happen when we attempt to
+            # delete an xform
+            mock.side_effect = IntegrityError
+
+            # this is necessary so that this test does not fail here
+            with self.assertRaises(IntegrityError):
+                delete_xform(xform=xform)
+
+        # nothing was deleted
+        self.assertTrue(XForm.objects.filter(id=xform.id).exists())
+        self.assertTrue(Instance.objects.filter(id=instance.id).exists())
+        self.assertTrue(Submission.objects.filter(id=submission.id).exists())
+        self.assertTrue(Bounty.objects.filter(id=bounty.id).exists())
+        self.assertTrue(Location.objects.filter(id=location.id).exists())
+        self.assertTrue(User.objects.filter(id=user.id).exists())
+        self.assertTrue(Task.objects.filter(id=task.id).exists())
+
+        # the task status did not change
+        task.refresh_from_db()
+        self.assertEqual(Task.ACTIVE, task.status)

--- a/kaznet/apps/ona/tests/test_utils.py
+++ b/kaznet/apps/ona/tests/test_utils.py
@@ -1,0 +1,113 @@
+"""
+Module for testing the Ona app utils
+"""
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.db import IntegrityError
+
+from dateutil.parser import parse
+from django_prices.models import Money
+from model_mommy import mommy
+
+from kaznet.apps.main.models import Bounty, Location, Submission, Task
+from kaznet.apps.main.tests.base import MainTestBase
+from kaznet.apps.ona.models import Instance
+from kaznet.apps.ona.utils import delete_instance
+
+
+class TestUtils(MainTestBase):
+    """
+    Tests for utils.py
+    """
+
+    def setUp(self):
+        super().setUp()
+
+    def test_delete_instance(self):
+        """
+        Test delete_instance
+        """
+        instance = mommy.make('ona.Instance')
+        task = mommy.make('main.Task', name='Quest')
+        location = mommy.make('main.Location', name='Voi')
+        user = mommy.make('auth.User', first_name='Coco')
+        bounty = mommy.make(
+            'main.Bounty', task=task, amount=Money('50', 'KES'))
+        submission = mommy.make(
+            'main.Submission',
+            task=task,
+            location=location,
+            user=user,
+            submission_time=parse("2018-09-04T00:00:00+00:00"),
+            status=Submission.APPROVED,
+            target_object_id=instance.id,
+            target_content_type=self.instance_type
+        )
+
+        delete_instance(instance=instance)
+
+        # the instance and submission were deleted
+        self.assertFalse(Instance.objects.filter(id=instance.id).exists())
+        self.assertFalse(Submission.objects.filter(id=submission.id).exists())
+
+        # these other models were not deleted
+        self.assertTrue(Bounty.objects.filter(id=bounty.id).exists())
+        self.assertTrue(Location.objects.filter(id=location.id).exists())
+        self.assertTrue(User.objects.filter(id=user.id).exists())
+        self.assertTrue(Task.objects.filter(id=task.id).exists())
+
+    def test_delete_instance_atomic(self):
+        """
+        Test delete_instance is atomic
+        """
+        instance = mommy.make('ona.Instance')
+        task = mommy.make('main.Task', name='Quest')
+        location = mommy.make('main.Location', name='Voi')
+        user = mommy.make('auth.User', first_name='Coco')
+        bounty = mommy.make(
+            'main.Bounty', task=task, amount=Money('50', 'KES'))
+        submission = mommy.make(
+            'main.Submission',
+            task=task,
+            location=location,
+            user=user,
+            submission_time=parse("2018-09-04T00:00:00+00:00"),
+            status=Submission.APPROVED,
+            target_object_id=instance.id,
+            target_content_type=self.instance_type
+        )
+
+        with patch('kaznet.apps.main.models.Submission.delete') as mock:
+            # we want a database-level error to happen when we attempt to
+            # delete a submission
+            mock.side_effect = IntegrityError
+
+            # this is necessary so that this test does not fail here
+            with self.assertRaises(IntegrityError):
+                delete_instance(instance=instance)
+
+        # nothing was deleted
+        self.assertTrue(Instance.objects.filter(id=instance.id).exists())
+        self.assertTrue(Submission.objects.filter(id=submission.id).exists())
+        self.assertTrue(Bounty.objects.filter(id=bounty.id).exists())
+        self.assertTrue(Location.objects.filter(id=location.id).exists())
+        self.assertTrue(User.objects.filter(id=user.id).exists())
+        self.assertTrue(Task.objects.filter(id=task.id).exists())
+
+        with patch('kaznet.apps.ona.models.Instance.delete') as mock:
+            # we want a database-level error to happen when we attempt to
+            # delete an instance
+            mock.side_effect = IntegrityError
+
+            # this is necessary so that this test does not fail here
+            with self.assertRaises(IntegrityError):
+                delete_instance(instance=instance)
+
+        # STILL nothing was deleted
+        self.assertTrue(Instance.objects.filter(id=instance.id).exists())
+        self.assertTrue(Submission.objects.filter(id=submission.id).exists())
+        self.assertTrue(Bounty.objects.filter(id=bounty.id).exists())
+        self.assertTrue(Location.objects.filter(id=location.id).exists())
+        self.assertTrue(User.objects.filter(id=user.id).exists())
+        self.assertTrue(Task.objects.filter(id=task.id).exists())

--- a/kaznet/apps/ona/tests/test_viewsets.py
+++ b/kaznet/apps/ona/tests/test_viewsets.py
@@ -167,6 +167,8 @@ class TestXFormViewSet(MainTestBase):
         """
         Test that you can search by title
         """
+        XForm.objects.all().delete()
+
         user = create_admin_user()
         mommy.make('ona.XForm', title='Coconut')
         mommy.make('ona.XForm', title='Generic', _quantity=7)

--- a/kaznet/apps/ona/utils.py
+++ b/kaznet/apps/ona/utils.py
@@ -6,6 +6,7 @@ from django.db import transaction
 from tasking.utils import get_allowed_contenttypes
 
 from kaznet.apps.main.models import Submission
+from kaznet.apps.ona.models import Instance
 
 
 @transaction.atomic
@@ -27,3 +28,20 @@ def delete_instance(instance: object):
         submission.delete()
     # finally, delete the instance itself
     instance.delete()
+
+
+@transaction.atomic
+def delete_xform(xform: object):
+    """
+    This method attempts to cleanly delete an Onadata XForm as well as all
+    associated Instances and Submissions.  The entire transaction is atomic
+    and is only successfully committed to the database when everything PASSES
+    """
+    # get all Instances
+    # pylint: disable=no-member
+    instances = Instance.objects.filter(xform=xform)
+    # delete all instances and submissions safely
+    for instance in instances:
+        delete_instance(instance)
+    # finally delete the XForm in a way that singals are sent
+    xform.delete()

--- a/kaznet/apps/ona/utils.py
+++ b/kaznet/apps/ona/utils.py
@@ -18,7 +18,7 @@ def delete_instance(instance: object):
     # get the instance contenttype
     instance_type = get_allowed_contenttypes().filter(model='instance').first()
     # get all related submissions
-    submissions = Submission.objects.filter(
+    submissions = Submission.objects.filter(  # pylint: disable=no-member
         target_object_id=instance.id,
         target_content_type=instance_type
     )

--- a/kaznet/apps/ona/utils.py
+++ b/kaznet/apps/ona/utils.py
@@ -1,0 +1,29 @@
+"""
+utils module for Ona app
+"""
+from django.db import transaction
+
+from tasking.utils import get_allowed_contenttypes
+
+from kaznet.apps.main.models import Submission
+
+
+@transaction.atomic
+def delete_instance(instance: object):
+    """
+    This method attempts to cleanly delete an Onadata Instance as well as all
+    associated Submissions.  The entire transaction is atomic and is only
+    successfully committed to the database when everything PASSES
+    """
+    # get the instance contenttype
+    instance_type = get_allowed_contenttypes().filter(model='instance').first()
+    # get all related submissions
+    submissions = Submission.objects.filter(
+        target_object_id=instance.id,
+        target_content_type=instance_type
+    )
+    # delete submissions in a way that signals are sent
+    for submission in submissions:
+        submission.delete()
+    # finally, delete the instance itself
+    instance.delete()

--- a/kaznet/settings/local_settings.example.py
+++ b/kaznet/settings/local_settings.example.py
@@ -47,6 +47,10 @@ CELERY_ROUTES = {
         'queue': 'submissions'},
     'kaznet.apps.ona.tasks.task_sync_form_updated_instances': {
         'queue': 'submissions'},
+    'kaznet.apps.ona.tasks.task_sync_deleted_instances': {
+        'queue': 'submissions'},
+    'kaznet.apps.ona.tasks.task_sync_form_deleted_instances': {
+        'queue': 'submissions'},
     'kaznet.apps.ona.tasks.task_fetch_projects': {'queue': 'forms'},
 }
 
@@ -59,9 +63,23 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'task_sync_updated_instances',
         'schedule': crontab(hour='*/1'),  # every 1 hr
     },
+    'sync_deleted_instances': {
+        'task': 'task_sync_deleted_instances',
+        'schedule': crontab(hour='*/1'),  # every 1 hr
+    },
     'fetch_projects': {
         'task': 'task_fetch_projects',
         'schedule': crontab(hour='*', minute='*/15'),  # every 15 minutes
+        'kwargs': {'username': 'the one username'}
+    },
+    'sync_deleted_forms': {
+        'task': 'task_sync_deleted_xforms',
+        'schedule': crontab(hour='*/6', minute='0'),  # every 6 hours
+        'kwargs': {'username': 'the one username'}
+    },
+    'sync_deleted_projects': {
+        'task': ' task_sync_deleted_projects',
+        'schedule': crontab(hour='*/12', minute='0'),  # every 12 hurs
         'kwargs': {'username': 'the one username'}
     },
     'process_user_profiles': {


### PR DESCRIPTION
Add tasks and methods to safely delete Onadata Instances, XForms and Projects.

Fix: #290 

One of the PRs that deal with #291
