### PR TITLE
Fix bug in project delete sync

### DIFF
--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -674,21 +674,24 @@ def create_form_webhook(
         return response
 
 
-def sync_deleted_projects(username: str = settings.ONA_USERNAME):
+def sync_deleted_projects(usernames: list):
     """
     Checks for deleted projects on Onadata
     If it finds any, it deletes them locally
     """
-    onadata_projects = get_projects(username=username)
-    if isinstance(onadata_projects, list) and onadata_projects:
-        onadata_project_pks = [rec['projectid'] for rec in onadata_projects]
-        local_projects = Project.objects.filter(deleted_at=None)
-        deleted_projects = local_projects.exclude(
-            ona_pk__in=onadata_project_pks)
+    onadata_project_pks = []
+    for username in usernames:
+        onadata_projects = get_projects(username=username)
+        if isinstance(onadata_projects, list) and onadata_projects:
+            onadata_project_pks = onadata_project_pks + [
+                    rec['projectid'] for rec in onadata_projects]
 
-        # delete projects safely
-        for proj in deleted_projects:
-            delete_project(proj)
+    local_projects = Project.objects.filter(deleted_at=None)
+    deleted_projects = local_projects.exclude(ona_pk__in=onadata_project_pks)
+
+    # delete projects safely
+    for proj in deleted_projects:
+        delete_project(proj)
 
 
 def sync_deleted_xforms(username: str = settings.ONA_USERNAME):

--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -684,7 +684,7 @@ def sync_deleted_projects(usernames: list):
         onadata_projects = get_projects(username=username)
         if isinstance(onadata_projects, list) and onadata_projects:
             onadata_project_pks = onadata_project_pks + [
-                    rec['projectid'] for rec in onadata_projects]
+                rec['projectid'] for rec in onadata_projects]
 
     local_projects = Project.objects.filter(deleted_at=None)
     deleted_projects = local_projects.exclude(ona_pk__in=onadata_project_pks)

--- a/kaznet/apps/ona/tasks.py
+++ b/kaznet/apps/ona/tasks.py
@@ -189,8 +189,8 @@ def task_sync_deleted_xforms(username: str):
 
 # pylint: disable=not-callable
 @celery_task(name="task_sync_deleted_projects")
-def task_sync_deleted_projects(username: str):
+def task_sync_deleted_projects(usernames: list):
     """
     checks for deleted projects and syncs them
     """
-    sync_deleted_projects(username=username)
+    sync_deleted_projects(usernames=usernames)

--- a/kaznet/apps/ona/tests/test_celery_tasks.py
+++ b/kaznet/apps/ona/tests/test_celery_tasks.py
@@ -587,5 +587,5 @@ class TestCeleryTasks(MainTestBase):
         Test task_sync_deleted_projects
         """
         # call the task
-        task_sync_deleted_projects(username="mosh")
-        mock.assert_called_once_with(username="mosh")
+        task_sync_deleted_projects(usernames=["coco", "mosh"])
+        mock.assert_called_once_with(usernames=["coco", "mosh"])

--- a/kaznet/settings/local_settings.example.py
+++ b/kaznet/settings/local_settings.example.py
@@ -60,7 +60,7 @@ CELERY_BEAT_SCHEDULE = {
     'sync_deleted_projects': {
         'task': 'task_sync_deleted_projects',
         'schedule': crontab(hour='*/12', minute='0'),  # every 12 hours
-        'kwargs': {'username': 'kaznet'}
+        'kwargs': {'usernames': ['kaznet', 'kaznettest']}
     },
     'sync_deleted_xforms': {
         'task': 'task_sync_deleted_xforms',
@@ -71,11 +71,6 @@ CELERY_BEAT_SCHEDULE = {
     'fetch_user_projects': {
         'task': 'task_fetch_projects',
         'schedule': crontab(hour='*', minute='*/5'),  # every 5 minutes
-        'kwargs': {'username': 'kaznettest'}
-    },
-    'sync_deleted_user_projects': {
-        'task': 'task_sync_deleted_projects',
-        'schedule': crontab(hour='*/12', minute='30'),  # every 12 hours
         'kwargs': {'username': 'kaznettest'}
     },
     'sync_deleted_user_xforms': {

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='kaznet',
-    version="1.0.5",
+    version="1.0.6",
     description='Tasking application built on top of Onadata',
     license='Apache 2.0',
     author='Ona Systems Inc',


### PR DESCRIPTION
Get projects for all usernames at once so that you can properly compare project pks that exist at Onadata with the local pks.