### PR TITLE
Sync automatic Submission Reviews with onadata 

### DIFF
--- a/kaznet/apps/main/api.py
+++ b/kaznet/apps/main/api.py
@@ -117,7 +117,7 @@ def create_submission(ona_instance: object):
     # call sync_submission_review based on validated_data[status]
     #  and the json field
     task_sync_submission_review.delay(
-        ona_instance.id, validated_data['status'])
+        ona_instance.id, validated_data['status'], validated_data['comments'])
 
     if validated_data['status'] == Submission.REJECTED:
         validated_data['valid'] = False

--- a/kaznet/apps/main/api.py
+++ b/kaznet/apps/main/api.py
@@ -15,6 +15,8 @@ from kaznet.apps.main.common_tags import (INCORRECT_LOCATION,
 from kaznet.apps.main.models import Location, Submission, TaskOccurrence, \
     TaskLocation
 from kaznet.apps.main.serializers import KaznetSubmissionSerializer
+from kaznet.apps.ona.tasks import task_sync_submission_review
+from kaznet.apps.ona.api import convert_ona_to_kaznet_submission_status
 
 
 # pylint: disable=too-many-branches
@@ -53,6 +55,9 @@ def create_submission(ona_instance: object):
             ona_status=data[settings.ONA_STATUS_FIELD])
         validated_data['comments'] = str(
             data.get(settings.ONA_COMMENTS_FIELD, ""))
+        # indicate that the instance object's review status
+        # has already been synced
+        ona_instance.json["synced_with_ona_data"] = True
 
     # if submission hasn't had a review(pending), or no review information of
     # submission
@@ -109,6 +114,11 @@ def create_submission(ona_instance: object):
                 'id': location.first().id
             }
 
+    # call sync_submission_review based on validated_data[status]
+    #  and the json field
+    task_sync_submission_review.delay(
+        ona_instance.id, validated_data['status'])
+
     if validated_data['status'] == Submission.REJECTED:
         validated_data['valid'] = False
     else:
@@ -116,34 +126,6 @@ def create_submission(ona_instance: object):
     serializer_instance = KaznetSubmissionSerializer(data=validated_data)
     if serializer_instance.is_valid():
         return serializer_instance.save()
-    return None
-
-
-def convert_ona_to_kaznet_submission_status(ona_status: str):
-    """
-    Convert Ona Instance statuses (1, 2, 3) to kaznet submission statuses
-    ('a', 'b', 'c')
-    """
-    if ona_status == settings.ONA_SUBMISSION_REVIEW_APPROVED:
-        return Submission.APPROVED
-    if ona_status == settings.ONA_SUBMISSION_REVIEW_REJECTED:
-        return Submission.REJECTED
-    if ona_status == settings.ONA_SUBMISSION_REVIEW_PENDING:
-        return Submission.PENDING
-    return None
-
-
-def convert_kaznet_to_ona_submission_status(kaznet_status: str):
-    """
-    Convert kaznet submission statuses ('a', 'b', 'c') to Ona Instance
-    statuses (1, 2, 3)
-    """
-    if kaznet_status == Submission.APPROVED:
-        return settings.ONA_SUBMISSION_REVIEW_APPROVED
-    if kaznet_status == Submission.REJECTED:
-        return settings.ONA_SUBMISSION_REVIEW_REJECTED
-    if kaznet_status == Submission.PENDING:
-        return settings.ONA_SUBMISSION_REVIEW_PENDING
     return None
 
 

--- a/kaznet/apps/main/tasks.py
+++ b/kaznet/apps/main/tasks.py
@@ -10,6 +10,7 @@ from kaznet.apps.main.models import Task, Bounty
 from kaznet.apps.main.models import TaskOccurrence
 from kaznet.apps.main.utils import create_occurrences
 from kaznet.apps.ona.models import Instance
+from kaznet.apps.ona.api import sync_submission_review
 
 
 @celery_task(name="task_create_occurrences")  # pylint: disable=not-callable
@@ -35,7 +36,8 @@ def task_create_submission(instance_id: int):
     except Instance.DoesNotExist:  # pylint: disable=no-member
         pass
     else:
-        create_submission(ona_instance=instance)
+        submission = create_submission(ona_instance=instance)
+        sync_submission_review(submission)
 
 
 @celery_task(name="task_past_end_date")  # pylint: disable=not-callable

--- a/kaznet/apps/main/tasks.py
+++ b/kaznet/apps/main/tasks.py
@@ -10,7 +10,6 @@ from kaznet.apps.main.models import Task, Bounty
 from kaznet.apps.main.models import TaskOccurrence
 from kaznet.apps.main.utils import create_occurrences
 from kaznet.apps.ona.models import Instance
-from kaznet.apps.ona.api import sync_submission_review
 
 
 @celery_task(name="task_create_occurrences")  # pylint: disable=not-callable
@@ -36,8 +35,7 @@ def task_create_submission(instance_id: int):
     except Instance.DoesNotExist:  # pylint: disable=no-member
         pass
     else:
-        submission = create_submission(ona_instance=instance)
-        #sync_submission_review(submission)
+        create_submission(ona_instance=instance)
 
 
 @celery_task(name="task_past_end_date")  # pylint: disable=not-callable

--- a/kaznet/apps/main/tasks.py
+++ b/kaznet/apps/main/tasks.py
@@ -37,7 +37,7 @@ def task_create_submission(instance_id: int):
         pass
     else:
         submission = create_submission(ona_instance=instance)
-        sync_submission_review(submission)
+        #sync_submission_review(submission)
 
 
 @celery_task(name="task_past_end_date")  # pylint: disable=not-callable

--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -322,17 +322,18 @@ def fetch_form_data(  # pylint: disable=too-many-arguments
     return request(url=url, method='GET', args=query_params)
 
 
-def sync_submission_review(instance_id, ona_review_status):
+def sync_submission_review(instance_id, ona_review_status, comment):
     """
     ensure Submission is in sync with Submission in onadata.
     """
-    args = {"status": ona_review_status,
+    args = {'note': comment, "status": ona_review_status,
             "instance": instance_id}
-    headers = {"Authorization": "TempToken "+temp_tocken}
     instance = Instance.objects.all().filter(id=instance_id)
     if not instance.json.get("synced_with_ona_data"):
         url = urljoin(settings.ONA_BASE_URL, 'api/v1/submissionreview.json')
-        request(url, args, method='POST', headers=headers)
+        reply = request(url, args, method='POST')
+        if reply["instance"].trim() == instance_id+"":
+            instance["synced_with_ona_data"] = True
 
 
 def sync_updated_instances(form_id: int):

--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -328,21 +328,11 @@ def sync_submission_review(instance_id, ona_review_status):
     """
     args = {"status": ona_review_status,
             "instance": instance_id}
-    temp_tocken = get_temp_tocken()
     headers = {"Authorization": "TempToken "+temp_tocken}
     instance = Instance.objects.all().filter(id=instance_id)
     if not instance.json.get("synced_with_ona_data"):
         url = urljoin(settings.ONA_BASE_URL, 'api/v1/submissionreview.json')
         request(url, args, method='POST', headers=headers)
-
-
-def get_temp_tocken():
-    """
-    get temp tocken
-    """
-    url = urljoin(settings.ONA_BASE_URL, "api/v1/user")
-    response = request(url, method="GET")
-    return response['temp_token']
 
 
 def sync_updated_instances(form_id: int):

--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -295,6 +295,17 @@ def fetch_form_data(  # pylint: disable=too-many-arguments
     return request(url=url, method='GET', args=query_params)
 
 
+def sync_submission_review(submission: None):
+    """
+    ensure Submission is in sync with Submission in onadata.
+    """
+    args = {"status": submission.status,
+            "instance": submission.target_object_id}
+    if not submission.json.get("synced_with_ona_data"):
+        url = urljoin(settings.ONA_BASE_URL, 'api/v1/submissionreview.json')
+        request(url, args, method='POST')
+
+
 def sync_updated_instances(form_id: int):
     """
     Attempts to get and sync updated instances from Onadata

--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -328,12 +328,12 @@ def sync_submission_review(instance_id, ona_review_status, comment):
     """
     args = {'note': comment, "status": ona_review_status,
             "instance": instance_id}
-    instance = Instance.objects.all().filter(id=instance_id)
+    instance = Instance.objects.get(ona_pk=instance_id)
     if not instance.json.get("synced_with_ona_data"):
         url = urljoin(settings.ONA_BASE_URL, 'api/v1/submissionreview.json')
         reply = request(url, args, method='POST')
-        if reply["instance"].trim() == instance_id+"":
-            instance["synced_with_ona_data"] = True
+        if reply["instance"].strip() == str(instance_id):
+            instance.json["synced_with_ona_data"] = True
 
 
 def sync_updated_instances(form_id: int):

--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -322,7 +322,8 @@ def fetch_form_data(  # pylint: disable=too-many-arguments
     return request(url=url, method='GET', args=query_params)
 
 
-def sync_submission_review(instance_id, ona_review_status, comment):
+def sync_submission_review(instance_id: int,
+                           ona_review_status: str, comment: str):
     """
     ensure Submission is in sync with Submission in onadata.
     """
@@ -330,15 +331,14 @@ def sync_submission_review(instance_id, ona_review_status, comment):
             "instance": instance_id}
     try:
         instance = Instance.objects.get(ona_pk=instance_id)
+    except Instance.DoesNotExist:  # pylint: disable=no-member
+        pass
+    else:
         # record submission review status and
         # comment on json field of instances
         instance.json["ona_review_status"] = ona_review_status
         instance.json["review_comment"] = comment
         instance.save()
-
-    except Instance.DoesNotExist:  # pylint: disable=no-member
-        pass
-    else:
         if instance.json.get("synced_with_ona_data") is not True:
             url = urljoin(settings.ONA_BASE_URL,
                           'api/v1/submissionreview.json')

--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -117,12 +117,12 @@ def convert_kaznet_to_ona_submission_status(kaznet_status: str):
     return None
 
 
-def request(url: str, args: dict = None, method: str = 'GET', headers=None):
+def request(url: str, args: dict = None, method: str = 'GET'):
     """
     Custom Method that requests data from requests_session
     and confirms it has a valid JSON return
     """
-    response = request_session(url, method, args, headers)
+    response = request_session(url, method, args)
     try:
         # you only come here if we can understand the API response
         return response.json()
@@ -334,6 +334,7 @@ def sync_submission_review(instance_id, ona_review_status, comment):
         reply = request(url, args, method='POST')
         if reply["instance"].strip() == str(instance_id):
             instance.json["synced_with_ona_data"] = True
+            instance.save()
 
 
 def sync_updated_instances(form_id: int):

--- a/kaznet/apps/ona/api.py
+++ b/kaznet/apps/ona/api.py
@@ -4,7 +4,6 @@ with the OnaData API
 """
 import json
 from urllib.parse import urljoin
-from requests.auth import HTTPBasicAuth
 
 import dateutil.parser
 import requests
@@ -310,12 +309,11 @@ def sync_submission_review(submission: None):
     if not submission.json.get("synced_with_ona_data"):
         url = urljoin(settings.ONA_BASE_URL, 'api/v1/submissionreview.json')
         response = request(url, args, method='POST', headers=headers)
-        #so based on the response we will decide if the sync was done or not
         if response["status"] and response["status"] == submission.status:
             print("something worked really well")
         elif response["status"]:
             print("something worked but now how you would have wanted it to")
-        else: 
+        else:
             print("nothing worked:-(")
 
 

--- a/kaznet/apps/ona/tasks.py
+++ b/kaznet/apps/ona/tasks.py
@@ -227,8 +227,8 @@ def task_sync_xform_can_submit_checks():
 
 # pylint: disable=not-callable
 @celery_task(name="task_sync_submission_review")
-def task_sync_submission_review(instance_id, ona_review_status):
+def task_sync_submission_review(instance_id, ona_review_status, comment):
     """
     Sync auto review of submission with its review on onadata
     """
-    sync_submission_review(instance_id, ona_review_status)
+    sync_submission_review(instance_id, ona_review_status, comment)

--- a/kaznet/apps/ona/tasks.py
+++ b/kaznet/apps/ona/tasks.py
@@ -22,6 +22,7 @@ from kaznet.apps.ona.api import (create_filtered_data_sets,
                                  update_user_profile_metadata)
 from kaznet.apps.ona.models import XForm
 from kaznet.apps.ona.utils import check_if_users_can_submit_to_form
+from kaznet.apps.ona.api import sync_submission_review
 
 
 @celery_task(name="task_fetch_projects")  # pylint: disable=not-callable
@@ -222,3 +223,12 @@ def task_sync_xform_can_submit_checks():
     xforms = XForm.objects.filter(deleted_at=None)
     for xform in xforms:
         task_check_if_users_can_submit_to_form.delay(xform_id=xform.id)
+
+
+# pylint: disable=not-callable
+@celery_task(name="task_sync_submission_review")
+def task_sync_submission_review(instance_id, ona_review_status):
+    """
+    Sync auto review of submission with its review on onadata
+    """
+    sync_submission_review(instance_id, ona_review_status)

--- a/kaznet/apps/ona/tasks.py
+++ b/kaznet/apps/ona/tasks.py
@@ -4,6 +4,7 @@ Celery tasks module for Ona app
 from datetime import timedelta
 from time import sleep
 from urllib.parse import urljoin
+from django.conf import settings
 
 from celery import task as celery_task
 from django.contrib.auth.models import User
@@ -28,6 +29,7 @@ def task_fetch_projects(username: str):
     """
     Fetches and processes projects from Onadata
     """
+    print(settings.ONA_BASE_URL)
     # get the projects from Onadata's API
     projects = get_projects(username=username)
     # save the projects locally

--- a/kaznet/apps/ona/tests/test_api.py
+++ b/kaznet/apps/ona/tests/test_api.py
@@ -1789,7 +1789,7 @@ class TestApiMethods(MainTestBase):
         request_method_mock.return_value = mock_reply
 
         # make an instance
-        mommy.make('ona.Instance', ona_pk=37511)
+        instance = mommy.make('ona.Instance', ona_pk=37511)
         # call sync_submission_review
         sync_submission_review(instance_id, ona_review_status, comment)
 
@@ -1798,3 +1798,8 @@ class TestApiMethods(MainTestBase):
         args = {'note': comment, "status": ona_review_status,
                 "instance": instance_id}
         request_method_mock.assert_called_with(url, args, method="POST")
+
+        #test that instance object has synced_with_ona_data set to True
+        instance = Instance.objects.get(ona_pk=instance_id)
+        self.assertTrue(instance.json.get("synced_with_ona_data"))
+

--- a/kaznet/apps/ona/tests/test_api.py
+++ b/kaznet/apps/ona/tests/test_api.py
@@ -1799,7 +1799,6 @@ class TestApiMethods(MainTestBase):
                 "instance": instance_id}
         request_method_mock.assert_called_with(url, args, method="POST")
 
-        #test that instance object has synced_with_ona_data set to True
-        instance = Instance.objects.get(ona_pk=instance_id)
+        # test that instance object has synced_with_ona_data set to True
+        instance.refresh_from_db()
         self.assertTrue(instance.json.get("synced_with_ona_data"))
-

--- a/kaznet/apps/ona/tests/test_api.py
+++ b/kaznet/apps/ona/tests/test_api.py
@@ -33,9 +33,7 @@ from kaznet.apps.ona.api import (create_filtered_data_sets,
                                  request_session, sync_deleted_instances,
                                  sync_deleted_projects, sync_deleted_xforms,
                                  sync_updated_instances,
-                                 update_user_profile_metadata,
-                                 sync_submission_review)
-from kaznet.apps.ona.tasks import task_fetch_projects
+                                 update_user_profile_metadata)
 from kaznet.apps.ona.models import Instance, Project, XForm
 from kaznet.apps.users.models import UserProfile
 
@@ -1770,4 +1768,3 @@ class TestApiMethods(MainTestBase):
         self.assertTrue(Instance.objects.filter(id=instance2.id).exists())
         task.refresh_from_db()
         self.assertEqual(0, task.get_submissions())
-        

--- a/kaznet/apps/ona/tests/test_api.py
+++ b/kaznet/apps/ona/tests/test_api.py
@@ -33,7 +33,9 @@ from kaznet.apps.ona.api import (create_filtered_data_sets,
                                  request_session, sync_deleted_instances,
                                  sync_deleted_projects, sync_deleted_xforms,
                                  sync_updated_instances,
-                                 update_user_profile_metadata)
+                                 update_user_profile_metadata,
+                                 sync_submission_review)
+from kaznet.apps.ona.tasks import task_fetch_projects
 from kaznet.apps.ona.models import Instance, Project, XForm
 from kaznet.apps.users.models import UserProfile
 
@@ -1768,3 +1770,4 @@ class TestApiMethods(MainTestBase):
         self.assertTrue(Instance.objects.filter(id=instance2.id).exists())
         task.refresh_from_db()
         self.assertEqual(0, task.get_submissions())
+        

--- a/kaznet/apps/ona/tests/test_api.py
+++ b/kaznet/apps/ona/tests/test_api.py
@@ -1790,11 +1790,11 @@ class TestApiMethods(MainTestBase):
 
         # make an instance
         mommy.make('ona.Instance', ona_pk=37511)
-        #call sync_submission_review
+        # call sync_submission_review
         sync_submission_review(instance_id, ona_review_status, comment)
-        
+
         # test that request receives the correct data
         url = urljoin(settings.ONA_BASE_URL, 'api/v1/submissionreview.json')
         args = {'note': comment, "status": ona_review_status,
-            "instance": instance_id}
+                "instance": instance_id}
         request_method_mock.assert_called_with(url, args, method="POST")

--- a/kaznet/settings/local_settings.example.py
+++ b/kaznet/settings/local_settings.example.py
@@ -39,6 +39,10 @@ CELERY_ROUTES = {
 }
 
 CELERY_BEAT_SCHEDULE = {
+    'sync_outdated_submission_reviews': {
+        'task': 'task_sync_outdated_submission_reviews',
+        'schedule': crontab(hour='*/6', minute='0'),  # every 6 hours
+    },
     'fetch_missing_instances': {
         'task': 'task_fetch_missing_instances',
         'schedule': crontab(hour='*', minute='*/30'),  # every 30 minutes

--- a/kaznet/settings/local_settings.example.py
+++ b/kaznet/settings/local_settings.example.py
@@ -41,7 +41,7 @@ CELERY_ROUTES = {
 CELERY_BEAT_SCHEDULE = {
     'sync_outdated_submission_reviews': {
         'task': 'task_sync_outdated_submission_reviews',
-        'schedule': crontab(hour='*/6', minute='0'),  # every 6 hours
+        'schedule': crontab(hour='*', minute='*/30'),  # every 30 minutes
     },
     'fetch_missing_instances': {
         'task': 'task_fetch_missing_instances',


### PR DESCRIPTION
Fix #270: sync automatic submission reviews with onadata and check every 6 hours for un-synced reviews and tests for it