### PR TITLE
Waits for Postgres to Come Up Before Running DroneCI Testing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,9 +2,11 @@ pipeline:
   build:
     image: onaio/python:${PYTHON_VERSION}
     commands:
+        - apt-get update && apt-get -y install netcat
         - pip install --upgrade pip
         - pip install tox
         - sleep 30
+        - nc -w 300 -vz postgres 5432
         - psql -h postgres -U kaznet -c "SELECT 1 AS COL;"
         - tox
     environment:


### PR DESCRIPTION
In the .drone.yml file, install netcat and use it wait until the
postgres service is fully up. The nc command will timeout after 300
seconds of not being able to connect to PostgreSQL.

Fixes #347

Signed-off-by: Jason Rogena <jason@rogena.me>