### PR TITLE
Fix location validation

### DIFF
--- a/kaznet/apps/main/api.py
+++ b/kaznet/apps/main/api.py
@@ -156,7 +156,8 @@ def get_locations(coords: list, task: object):
     # Check if we were able to successfully get coords
     # If we weren't then return None
     if coords and all(coords):
-        submission_point = Point(coords[0], coords[1])
+        # Expects coords to be passed in as latitude, longitude
+        submission_point = Point(coords[1], coords[0])
 
         # get task locations with a shapefile that has the submission_point
         # within its range
@@ -176,7 +177,10 @@ def validate_location(coords: list, task: object):
     Validates Submission Location
     """
     locations = get_locations(coords, task)
-    submission_point = Point(coords[0], coords[1])
+    # Onadata endpoint passes coordinates as Latitude, Longitude
+    # Point takes in coordinates as Longitude, Latitude
+    # Ref: https://docs.djangoproject.com/en/2.2/ref/contrib/gis/geos/
+    submission_point = Point(coords[1], coords[0])
 
     if locations:
         for location in locations:

--- a/kaznet/apps/main/tests/test_api.py
+++ b/kaznet/apps/main/tests/test_api.py
@@ -66,8 +66,8 @@ class TestAPIMethods(MainTestBase):
         data = {
             "_xform_id_string": "aFEjJKzULJbQYsmQzKcpL9",
             "_geolocation": [
-                36.776554,
-                -1.294328
+                -1.294328,
+                36.776554
             ],
             "_status": "submitted_via_web",
             "_review_status": settings.ONA_SUBMISSION_REVIEW_APPROVED,


### PR DESCRIPTION
This feature did not work correctly before and passed under the radar due to the fact the GPS of submissions is not automatically passed for every submission in ODK Collect(`_geolocation` is only passed when a GeoWidget is added to a form).

This PR seeks to fix the feature by accurately retrieving and processing the `_geolocation` passed by an `onadata` api