### PR TITLE
Fix bug where naive datetimes would fail validation

### DIFF
--- a/kaznet/apps/main/tests/test_api.py
+++ b/kaznet/apps/main/tests/test_api.py
@@ -338,6 +338,15 @@ class TestAPIMethods(MainTestBase):
         self.assertEqual(Submission.PENDING, status)
         self.assertEqual("", comment)
 
+        # Test still validates if timezone is not specified in submission_time
+        data['_submission_time'] = data['_submission_time'].replace(
+            '+00:00', '')
+        status, comment = validate_submission_time(
+            task, data['_submission_time'])
+
+        self.assertEqual(Submission.PENDING, status)
+        self.assertEqual("", comment)
+
     def test_validate_submission_limit(self):
         """
         Test that validate_submission_limit works as it should with valid data


### PR DESCRIPTION
Fixes an issue where datetime strings such as `2019-11-11T06:06:36` would not be properly validated due to their lack of timezone.

This PR fixes this issue by assuming timestring such as those are `UTC` timezones of which it calculates the `utcoffset` of the application and adds onto the `UTC` timezone in order to get a `datetime` object localized in the applications timezone.