### PR TITLE
Disable django_toolbar default requirement for production setups

### DIFF
--- a/kaznet/settings/common.py
+++ b/kaznet/settings/common.py
@@ -75,7 +75,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
 ]
 
 ROOT_URLCONF = 'kaznet.urls'

--- a/kaznet/urls.py
+++ b/kaznet/urls.py
@@ -59,7 +59,11 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
-    import debug_toolbar  # noqa
-    urlpatterns = [
-        path('__debug__/', include(debug_toolbar.urls)),
-    ] + urlpatterns
+    try:
+        import debug_toolbar  # noqa pylint: disable=E0401
+    except ModuleNotFoundError:
+        pass
+    else:
+        urlpatterns = [
+            path('__debug__/', include(debug_toolbar.urls)),
+        ] + urlpatterns


### PR DESCRIPTION
Fix #364